### PR TITLE
Optimize mobile hero section and CTA buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16076,3 +16076,73 @@ p.ttt {
         font-size: 44px !important;
         margin-bottom: 10px !important;
     }
+/* Custom Floating WhatsApp Button */
+.whatsapp-float {
+    position: fixed;
+    width: 60px;
+    height: 60px;
+    bottom: 40px;
+    right: 20px;
+    background-color: #25d366;
+    color: #FFF;
+    border-radius: 50px;
+    text-align: center;
+    box-shadow: 2px 2px 3px #999;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+.whatsapp-float:hover {
+    transform: scale(1.1);
+    background-color: #128c7e;
+}
+
+.whatsapp-float img {
+    width: 35px;
+    height: 35px;
+}
+
+/* Responsive adjustments for Hero Section */
+@media (max-width: 767px) {
+    h2.title.jkl {
+        font-size: 28px !important;
+        line-height: 1.3 !important;
+    }
+    figure.image.overlay-anim.jkl1 img {
+        max-width: 70% !important;
+        margin: 0 auto !important;
+        display: block !important;
+        height: auto !important;
+    }
+    .about-section {
+        padding: 40px 0 30px !important;
+    }
+    .about-section .image-column .inner-column {
+        margin-bottom: 25px !important;
+    }
+}
+
+/* Further refinements for mobile hero visibility */
+@media (max-width: 575px) {
+    h2.title.jkl {
+        font-size: 24px !important;
+        margin-bottom: 5px !important;
+    }
+    .about-section .content-column .inner-column .text p {
+        font-size: 14px !important;
+        line-height: 1.4 !important;
+        margin-bottom: 10px !important;
+    }
+    figure.image.overlay-anim.jkl1 img {
+        max-width: 60% !important;
+    }
+    .about-section {
+        padding: 20px 0 20px !important;
+    }
+    .about-section .image-column .inner-column {
+        margin-bottom: 15px !important;
+    }
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -80,15 +80,10 @@
     </nav>
 </header>
 
-<!-- Mobile Contact Quick Actions -->
-<div class="d-lg-none fixed-bottom bg-white border-top py-2 d-flex justify-content-around">
-    <a href="https://api.whatsapp.com/send?phone=+61430147281">
-        <img src="images/whatsapp.png" alt="WhatsApp" style="height:32px;">
-    </a>
-    <a href="tel:+61430147281">
-        <img src="images/call.png" alt="Call" style="height:32px;">
-    </a>
-</div>
+<!-- Floating WhatsApp Button -->
+<a href="https://api.whatsapp.com/send?phone=+61430147281" class="whatsapp-float" target="_blank">
+    <img src="images/whatsapp.png" alt="WhatsApp">
+</a>
 
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-HK5LK2BNRK"></script>

--- a/index.php
+++ b/index.php
@@ -75,7 +75,7 @@
                 </p>
               </div>
               <div class="btn-box d-sm-flex align-items-center justify-content-start">
-                <a href="contact-us.php" class="theme-btn">Contact Us</a>
+                <a href="tel:+61430147281" class="theme-btn">Call Now</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This change optimizes the hero section for mobile devices. It reduces the font size of the hero title and the dimensions of the hero image when viewed on screens smaller than 767px (with further reductions for 575px). The "Contact Us" button in the hero section has been replaced with a "Call Now" CTA. Additionally, the fixed-bottom contact bar on mobile has been replaced by a floating WhatsApp button, providing a cleaner and more modern UI.

---
*PR created automatically by Jules for task [7100037558782315803](https://jules.google.com/task/7100037558782315803) started by @Wictronix*